### PR TITLE
[ME-77] Change JWT library

### DIFF
--- a/authentication-api/auth/core/serializers.py
+++ b/authentication-api/auth/core/serializers.py
@@ -1,5 +1,5 @@
-from rest_auth.registration.serializers import RegisterSerializer
-from rest_auth.serializers import LoginSerializer
+from dj_rest_auth.registration.serializers import RegisterSerializer
+from dj_rest_auth.serializers import LoginSerializer
 
 from rest_framework import serializers
 

--- a/authentication-api/auth/core/tests/test_views.py
+++ b/authentication-api/auth/core/tests/test_views.py
@@ -48,7 +48,8 @@ def test_email_registration(api_client):
     )
 
     assert response.status_code == 201
-    assert "token" in response.data
+    assert "access_token" in response.data
+    assert "refresh_token" in response.data
 
 
 @pytest.mark.django_db
@@ -102,7 +103,8 @@ def test_email_login(api_client):
         reverse("rest_login"), data={"email": "user@example.com", "password": "1234example1234"},
     )
 
-    assert "token" in response.data
+    assert "access_token" in response.data
+    assert "refresh_token" in response.data
     assert response.status_code == 200
 
 
@@ -142,8 +144,7 @@ def test_email_password_change(api_client):
     )
 
     assert response.status_code == 201
-    token = response.data["token"]
-
+    token = response.data["access_token"]
     api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {token}")
 
     new_password = "1234example1234-changed"
@@ -254,7 +255,7 @@ def test_user_email_logout(api_client):
         },
     )
 
-    token = response.data["token"]
+    token = response.data["access_token"]
     api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {token}")
     response = api_client.post(reverse("rest_logout"))
 
@@ -277,20 +278,20 @@ def test_verify_token(api_client):
         },
     )
 
-    token = response.data["token"]
+    token = response.data["access_token"]
 
     response = api_client.post(reverse("rest_verify_token"), data={"token": token})
 
     assert response.status_code == 200
-    assert "token" in response.data
+    assert response.data == {}
 
 
 @pytest.mark.django_db
 def test_verify_token_invalid(api_client):
     response = api_client.post(reverse("rest_verify_token"), data={"token": "invalidtoken"})
 
-    assert response.status_code == 400
-    assert not response.data.get("token")
+    assert response.status_code == 401
+    assert not response.data.get("access_token")
 
 
 @pytest.mark.django_db
@@ -306,12 +307,12 @@ def test_refresh_token(api_client):
         },
     )
 
-    token = response.data["token"]
+    token = response.data["refresh_token"]
 
-    response = api_client.post(reverse("rest_refresh_token"), data={"token": token})
+    response = api_client.post(reverse("rest_refresh_token"), data={"refresh": token})
 
     assert response.status_code == 200
-    assert "token" in response.data
+    assert "access" in response.data
 
 
 @pytest.mark.django_db
@@ -319,7 +320,7 @@ def test_refresh_token_invalid(api_client):
     response = api_client.post(reverse("rest_refresh_token"), data={"token": "invalidtoken"})
 
     assert response.status_code == 400
-    assert not response.data.get("token")
+    assert not response.data.get("access")
 
 
 @pytest.mark.django_db
@@ -346,7 +347,7 @@ def test_admin_panel_login_success(api_client):
         data={"email": "user@example.com", "password": "1234example1234"},
     )
 
-    assert "token" in response.data
+    assert "access_token" in response.data
     assert response.status_code == 200
 
 

--- a/authentication-api/auth/core/views.py
+++ b/authentication-api/auth/core/views.py
@@ -1,13 +1,13 @@
 from allauth.account.views import ConfirmEmailView
-from rest_auth.registration.views import RegisterView, VerifyEmailView
-from rest_auth.views import (
+from dj_rest_auth.registration.views import RegisterView, VerifyEmailView
+from dj_rest_auth.views import (
     LoginView,
     LogoutView,
     PasswordChangeView,
     PasswordResetConfirmView,
     PasswordResetView,
 )
-from rest_framework_jwt.views import RefreshJSONWebToken, VerifyJSONWebToken
+from rest_framework_simplejwt.views import TokenVerifyView, TokenRefreshView
 
 from django.urls import reverse
 
@@ -55,11 +55,11 @@ class ConfirmEmail(ConfirmEmailView):
         return reverse("account_confirm_email", kwargs={"key": self.kwargs["key"]})
 
 
-class RefreshToken(RefreshJSONWebToken):
+class RefreshToken(TokenRefreshView):
     permission_classes = (AllowAny,)
 
 
-class VerifyToken(VerifyJSONWebToken):
+class VerifyToken(TokenVerifyView):
     permission_classes = (AllowAny,)
 
 

--- a/authentication-api/config/settings/base.py
+++ b/authentication-api/config/settings/base.py
@@ -1,7 +1,6 @@
 """
 Base settings to build other settings files upon.
 """
-import datetime
 import os
 
 import environ
@@ -82,8 +81,8 @@ THIRD_PARTY_APPS = [
     "allauth.socialaccount.providers.google",
     "rest_framework",
     "rest_framework.authtoken",
-    "rest_auth",
-    "rest_auth.registration",
+    "dj_rest_auth",
+    "dj_rest_auth.registration",
     "celery",
 ]
 
@@ -184,7 +183,7 @@ REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": env.int("DJANGO_PAGINATION_LIMIT", default=10),
     "DEFAULT_AUTHENTICATION_CLASSES": [
-        "rest_framework_jwt.authentication.JSONWebTokenAuthentication",
+        "dj_rest_auth.utils.JWTCookieAuthentication",
     ],
     "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.IsAuthenticated"],
     "DEFAULT_RENDERER_CLASSES": ["rest_framework.renderers.JSONRenderer"],
@@ -312,32 +311,7 @@ ACCOUNT_AUTHENTICATION_METHOD = "email"
 ACCOUNT_UNIQUE_EMAIL = True
 
 REST_USE_JWT = True
-
-# JWT settings
-JWT_AUTH = {
-    "JWT_ENCODE_HANDLER": "rest_framework_jwt.utils.jwt_encode_handler",
-    "JWT_DECODE_HANDLER": "rest_framework_jwt.utils.jwt_decode_handler",
-    "JWT_PAYLOAD_HANDLER": "rest_framework_jwt.utils.jwt_payload_handler",
-    "JWT_PAYLOAD_GET_USER_ID_HANDLER": (
-        "rest_framework_jwt.utils.jwt_get_user_id_from_payload_handler"
-    ),
-    "JWT_RESPONSE_PAYLOAD_HANDLER": "rest_framework_jwt.utils.jwt_response_payload_handler",
-    "JWT_SECRET_KEY": SECRET_KEY,
-    "JWT_GET_USER_SECRET_KEY": None,
-    "JWT_PUBLIC_KEY": None,
-    "JWT_PRIVATE_KEY": None,
-    "JWT_ALGORITHM": "HS256",
-    "JWT_VERIFY": True,
-    "JWT_VERIFY_EXPIRATION": True,
-    "JWT_LEEWAY": 0,
-    "JWT_EXPIRATION_DELTA": datetime.timedelta(hours=1),
-    "JWT_AUDIENCE": None,
-    "JWT_ISSUER": None,
-    "JWT_ALLOW_REFRESH": True,
-    "JWT_REFRESH_EXPIRATION_DELTA": datetime.timedelta(days=1),
-    "JWT_AUTH_HEADER_PREFIX": "Bearer",
-    "JWT_AUTH_COOKIE": None,
-}
+JWT_AUTH_COOKIE = "jwt_token"
 
 REST_AUTH_SERIALIZERS = {
     "USER_DETAILS_SERIALIZER": "auth.user.serializers.UserSerializer",

--- a/authentication-api/requirements/base.in
+++ b/authentication-api/requirements/base.in
@@ -9,7 +9,7 @@ django-filter
 django-model-utils
 django-redis
 drf_yasg
-django-rest-auth[with_social]
+dj-rest-auth[with_social]
 whitenoise
 packaging
 python-dateutil
@@ -19,6 +19,5 @@ boto3
 celery[redis]
 pyjwt
 cryptography
-djangorestframework-jwt
-djangorestframework-jsonapi
 django-rest-framework-proxy
+djangorestframework-simplejwt

--- a/authentication-api/requirements/base.txt
+++ b/authentication-api/requirements/base.txt
@@ -18,19 +18,19 @@ coreapi==2.3.3            # via drf-yasg
 coreschema==0.0.4         # via coreapi, drf-yasg
 cryptography==2.8         # via -r requirements/base.in
 defusedxml==0.6.0         # via python3-openid
-django-allauth==0.40.0    # via django-rest-auth
+dj-rest-auth[with_social]==1.0.5  # via -r requirements/base.in
+django-allauth==0.40.0    # via dj-rest-auth
 django-cors-headers==3.1.0  # via -r requirements/base.in
 django-environ==0.4.5     # via -r requirements/base.in
 django-filter==2.2.0      # via -r requirements/base.in
 django-model-utils==3.2.0  # via -r requirements/base.in
 django-redis==4.11.0      # via -r requirements/base.in
-django-rest-auth[with_social]==0.9.5  # via -r requirements/base.in
 django-rest-framework-proxy==1.6.0  # via -r requirements/base.in
 django-storages==1.8      # via -r requirements/base.in
-django==2.2.10            # via -r requirements/base.in, django-allauth, django-cors-headers, django-filter, django-model-utils, django-redis, django-rest-auth, django-storages, djangorestframework-jsonapi, drf-yasg
-djangorestframework-jsonapi==3.1.0  # via -r requirements/base.in
+django==2.2.10            # via -r requirements/base.in, dj-rest-auth, django-allauth, django-cors-headers, django-filter, django-model-utils, django-redis, django-rest-framework-proxy, django-storages, djangorestframework-simplejwt, drf-yasg
 djangorestframework-jwt==1.11.0  # via -r requirements/base.in
-djangorestframework==3.10.2  # via -r requirements/base.in, django-rest-auth, drf-yasg
+djangorestframework-simplejwt==4.4.0  # via -r requirements/base.in
+djangorestframework==3.10.2  # via -r requirements/base.in, dj-rest-auth, django-rest-framework-proxy, djangorestframework-simplejwt, drf-yasg
 docutils==0.15.2          # via botocore
 drf-yasg==1.16.1          # via -r requirements/base.in
 google-api-python-client==1.7.11  # via -r requirements/base.in
@@ -52,7 +52,7 @@ psycopg2==2.8.3           # via -r requirements/base.in
 pyasn1-modules==0.2.7     # via google-auth
 pyasn1==0.4.8             # via pyasn1-modules, rsa
 pycparser==2.19           # via cffi
-pyjwt==1.7.1              # via -r requirements/base.in, djangorestframework-jwt
+pyjwt==1.7.1              # via -r requirements/base.in, djangorestframework-jwt, djangorestframework-simplejwt
 pyparsing==2.4.5          # via packaging
 python-dateutil==2.8.0    # via -r requirements/base.in, botocore
 python3-openid==3.1.0     # via django-allauth
@@ -64,7 +64,7 @@ rsa==4.0                  # via google-auth
 ruamel.yaml.clib==0.1.2   # via ruamel.yaml
 ruamel.yaml==0.16.5       # via drf-yasg
 s3transfer==0.2.1         # via boto3
-six==1.12.0               # via argon2-cffi, cryptography, django-rest-auth, drf-yasg, google-api-python-client, google-auth, packaging, python-dateutil
+six==1.12.0               # via argon2-cffi, cryptography, drf-yasg, google-api-python-client, google-auth, packaging, python-dateutil
 sqlparse==0.3.0           # via django
 uritemplate==3.0.0        # via coreapi, drf-yasg, google-api-python-client
 urllib3==1.25.3           # via botocore, requests

--- a/authentication-api/requirements/local.txt
+++ b/authentication-api/requirements/local.txt
@@ -26,19 +26,19 @@ coverage==4.5.4           # via codecov, pytest-cov
 cryptography==2.8         # via -r requirements/././base.in, -r requirements/./base.in
 decorator==4.4.0          # via ipython, traitlets
 defusedxml==0.6.0         # via python3-openid
-django-allauth==0.40.0    # via django-rest-auth
+dj-rest-auth[with_social]==1.0.5  # via -r requirements/././base.in, -r requirements/./base.in
+django-allauth==0.40.0    # via dj-rest-auth
 django-cors-headers==3.1.0  # via -r requirements/././base.in, -r requirements/./base.in
 django-environ==0.4.5     # via -r requirements/././base.in, -r requirements/./base.in
 django-filter==2.2.0      # via -r requirements/././base.in, -r requirements/./base.in
 django-model-utils==3.2.0  # via -r requirements/././base.in, -r requirements/./base.in
 django-redis==4.11.0      # via -r requirements/././base.in, -r requirements/./base.in
-django-rest-auth[with_social]==0.9.5  # via -r requirements/././base.in, -r requirements/./base.in
 django-rest-framework-proxy==1.6.0  # via -r requirements/././base.in, -r requirements/./base.in
 django-storages==1.8      # via -r requirements/././base.in, -r requirements/./base.in
-django==2.2.10            # via -r requirements/././base.in, -r requirements/./base.in, django-allauth, django-cors-headers, django-filter, django-model-utils, django-redis, django-rest-auth, django-storages, djangorestframework-jsonapi, drf-yasg
-djangorestframework-jsonapi==3.1.0  # via -r requirements/././base.in, -r requirements/./base.in
+django==2.2.10            # via -r requirements/././base.in, -r requirements/./base.in, dj-rest-auth, django-allauth, django-cors-headers, django-filter, django-model-utils, django-redis, django-rest-framework-proxy, django-storages, djangorestframework-simplejwt, drf-yasg
 djangorestframework-jwt==1.11.0  # via -r requirements/././base.in, -r requirements/./base.in
-djangorestframework==3.10.2  # via -r requirements/././base.in, -r requirements/./base.in, django-rest-auth, drf-yasg
+djangorestframework-simplejwt==4.4.0  # via -r requirements/././base.in, -r requirements/./base.in
+djangorestframework==3.10.2  # via -r requirements/././base.in, -r requirements/./base.in, dj-rest-auth, django-rest-framework-proxy, djangorestframework-simplejwt, drf-yasg
 docutils==0.15.2          # via botocore
 drf-yasg==1.16.1          # via -r requirements/././base.in, -r requirements/./base.in
 entrypoints==0.3          # via flake8
@@ -82,7 +82,7 @@ pycodestyle==2.5.0        # via flake8
 pycparser==2.19           # via cffi
 pyflakes==2.1.1           # via flake8
 pygments==2.4.2           # via ipython
-pyjwt==1.7.1              # via -r requirements/././base.in, -r requirements/./base.in, djangorestframework-jwt
+pyjwt==1.7.1              # via -r requirements/././base.in, -r requirements/./base.in, djangorestframework-jwt, djangorestframework-simplejwt
 pyparsing==2.4.2          # via packaging
 pytest-cov==2.7.1         # via -r requirements/./test.in
 pytest-django==3.5.1      # via -r requirements/./test.in
@@ -102,7 +102,7 @@ rsa==4.0                  # via google-auth
 ruamel.yaml.clib==0.1.2   # via ruamel.yaml
 ruamel.yaml==0.16.5       # via drf-yasg
 s3transfer==0.2.1         # via boto3
-six==1.12.0               # via argon2-cffi, cryptography, django-rest-auth, drf-yasg, faker, freezegun, google-api-python-client, google-auth, packaging, pip-tools, prompt-toolkit, pytest-xdist, python-dateutil, requests-mock, traitlets
+six==1.12.0               # via argon2-cffi, cryptography, drf-yasg, faker, freezegun, google-api-python-client, google-auth, packaging, pip-tools, prompt-toolkit, pytest-xdist, python-dateutil, requests-mock, traitlets
 sqlparse==0.3.0           # via django
 termcolor==1.1.0          # via pytest-sugar
 text-unidecode==1.2       # via faker

--- a/authentication-api/requirements/production.txt
+++ b/authentication-api/requirements/production.txt
@@ -18,20 +18,20 @@ coreapi==2.3.3            # via drf-yasg
 coreschema==0.0.4         # via coreapi, drf-yasg
 cryptography==2.8         # via -r requirements/./base.in
 defusedxml==0.6.0         # via python3-openid
-django-allauth==0.40.0    # via django-rest-auth
+dj-rest-auth[with_social]==1.0.5  # via -r requirements/./base.in
+django-allauth==0.40.0    # via dj-rest-auth
 django-anymail[mailgun]==6.1.0  # via -r requirements/production.in
 django-cors-headers==3.1.0  # via -r requirements/./base.in
 django-environ==0.4.5     # via -r requirements/./base.in
 django-filter==2.2.0      # via -r requirements/./base.in
 django-model-utils==3.2.0  # via -r requirements/./base.in
 django-redis==4.11.0      # via -r requirements/./base.in
-django-rest-auth[with_social]==0.9.5  # via -r requirements/./base.in
 django-rest-framework-proxy==1.6.0  # via -r requirements/./base.in
 django-storages==1.8      # via -r requirements/./base.in
-django==2.2.10            # via -r requirements/./base.in, django-allauth, django-anymail, django-cors-headers, django-filter, django-model-utils, django-redis, django-rest-auth, django-storages, djangorestframework-jsonapi, drf-yasg
-djangorestframework-jsonapi==3.1.0  # via -r requirements/./base.in
+django==2.2.10            # via -r requirements/./base.in, dj-rest-auth, django-allauth, django-anymail, django-cors-headers, django-filter, django-model-utils, django-redis, django-rest-framework-proxy, django-storages, djangorestframework-simplejwt, drf-yasg
 djangorestframework-jwt==1.11.0  # via -r requirements/./base.in
-djangorestframework==3.10.2  # via -r requirements/./base.in, django-rest-auth, drf-yasg
+djangorestframework-simplejwt==4.4.0  # via -r requirements/./base.in
+djangorestframework==3.10.2  # via -r requirements/./base.in, dj-rest-auth, django-rest-framework-proxy, djangorestframework-simplejwt, drf-yasg
 docutils==0.15.2          # via botocore
 drf-yasg==1.16.1          # via -r requirements/./base.in
 google-api-python-client==1.7.11  # via -r requirements/./base.in
@@ -54,7 +54,7 @@ psycopg2==2.8.3           # via -r requirements/./base.in
 pyasn1-modules==0.2.7     # via google-auth
 pyasn1==0.4.8             # via pyasn1-modules, rsa
 pycparser==2.19           # via cffi
-pyjwt==1.7.1              # via -r requirements/./base.in, djangorestframework-jwt
+pyjwt==1.7.1              # via -r requirements/./base.in, djangorestframework-jwt, djangorestframework-simplejwt
 pyparsing==2.4.5          # via packaging
 python-dateutil==2.8.0    # via -r requirements/./base.in, botocore
 python3-openid==3.1.0     # via django-allauth
@@ -67,7 +67,7 @@ ruamel.yaml.clib==0.1.2   # via ruamel.yaml
 ruamel.yaml==0.16.5       # via drf-yasg
 s3transfer==0.2.1         # via boto3
 sentry-sdk==0.11.1        # via -r requirements/production.in
-six==1.12.0               # via argon2-cffi, cryptography, django-anymail, django-rest-auth, drf-yasg, google-api-python-client, google-auth, packaging, python-dateutil
+six==1.12.0               # via argon2-cffi, cryptography, django-anymail, drf-yasg, google-api-python-client, google-auth, packaging, python-dateutil
 sqlparse==0.3.0           # via django
 uritemplate==3.0.0        # via coreapi, drf-yasg, google-api-python-client
 urllib3==1.25.3           # via botocore, requests, sentry-sdk

--- a/authentication-api/requirements/test.txt
+++ b/authentication-api/requirements/test.txt
@@ -23,19 +23,19 @@ coreschema==0.0.4         # via coreapi, drf-yasg
 coverage==4.5.4           # via codecov, pytest-cov
 cryptography==2.8         # via -r requirements/./base.in
 defusedxml==0.6.0         # via python3-openid
-django-allauth==0.40.0    # via django-rest-auth
+dj-rest-auth[with_social]==1.0.5  # via -r requirements/./base.in
+django-allauth==0.40.0    # via dj-rest-auth
 django-cors-headers==3.1.0  # via -r requirements/./base.in
 django-environ==0.4.5     # via -r requirements/./base.in
 django-filter==2.2.0      # via -r requirements/./base.in
 django-model-utils==3.2.0  # via -r requirements/./base.in
 django-redis==4.11.0      # via -r requirements/./base.in
-django-rest-auth[with_social]==0.9.5  # via -r requirements/./base.in
 django-rest-framework-proxy==1.6.0  # via -r requirements/./base.in
 django-storages==1.8      # via -r requirements/./base.in
-django==2.2.10            # via -r requirements/./base.in, django-allauth, django-cors-headers, django-filter, django-model-utils, django-redis, django-rest-auth, django-storages, djangorestframework-jsonapi, drf-yasg
-djangorestframework-jsonapi==3.1.0  # via -r requirements/./base.in
+django==2.2.10            # via -r requirements/./base.in, dj-rest-auth, django-allauth, django-cors-headers, django-filter, django-model-utils, django-redis, django-rest-framework-proxy, django-storages, djangorestframework-simplejwt, drf-yasg
 djangorestframework-jwt==1.11.0  # via -r requirements/./base.in
-djangorestframework==3.10.2  # via -r requirements/./base.in, django-rest-auth, drf-yasg
+djangorestframework-simplejwt==4.4.0  # via -r requirements/./base.in
+djangorestframework==3.10.2  # via -r requirements/./base.in, dj-rest-auth, django-rest-framework-proxy, djangorestframework-simplejwt, drf-yasg
 docutils==0.15.2          # via botocore
 drf-yasg==1.16.1          # via -r requirements/./base.in
 entrypoints==0.3          # via flake8
@@ -68,7 +68,7 @@ pyasn1==0.4.8             # via pyasn1-modules, rsa
 pycodestyle==2.5.0        # via flake8
 pycparser==2.19           # via cffi
 pyflakes==2.1.1           # via flake8
-pyjwt==1.7.1              # via -r requirements/./base.in, djangorestframework-jwt
+pyjwt==1.7.1              # via -r requirements/./base.in, djangorestframework-jwt, djangorestframework-simplejwt
 pyparsing==2.4.2          # via packaging
 pytest-cov==2.7.1         # via -r requirements/test.in
 pytest-django==3.5.1      # via -r requirements/test.in
@@ -88,7 +88,7 @@ rsa==4.0                  # via google-auth
 ruamel.yaml.clib==0.1.2   # via ruamel.yaml
 ruamel.yaml==0.16.5       # via drf-yasg
 s3transfer==0.2.1         # via boto3
-six==1.12.0               # via argon2-cffi, cryptography, django-rest-auth, drf-yasg, faker, freezegun, google-api-python-client, google-auth, packaging, pytest-xdist, python-dateutil, requests-mock
+six==1.12.0               # via argon2-cffi, cryptography, drf-yasg, faker, freezegun, google-api-python-client, google-auth, packaging, pytest-xdist, python-dateutil, requests-mock
 sqlparse==0.3.0           # via django
 termcolor==1.1.0          # via pytest-sugar
 text-unidecode==1.2       # via faker


### PR DESCRIPTION
As djangorestframework_jwt in not longer maintained I decided to switch to djangorestframework_simplejwt which is right now officially pointed out in DRF documentation 