### PR TITLE
[ME-156] Hide add option button in test form conditionally

### DIFF
--- a/admin/src/views/App/components/CreateTest/index.jsx
+++ b/admin/src/views/App/components/CreateTest/index.jsx
@@ -37,7 +37,9 @@ export default function CreateTest(props) {
               {({ scopedFormData, getSource }) => (
                 <ArrayInput source={getSource("choices")} validate={[required()]} label="CHOICES">
                   <SimpleFormIterator
-                    disableAdd={scopedFormData && scopedFormData.choices.length > 1}
+                    disableAdd={
+                      scopedFormData && scopedFormData.choices && scopedFormData.choices.length > 1
+                    }
                   >
                     <TextInput source="answer" validate={[required()]} label="Answer" />
                     <NullableBooleanInput

--- a/admin/src/views/App/components/EditTest/index.jsx
+++ b/admin/src/views/App/components/EditTest/index.jsx
@@ -51,7 +51,9 @@ export default function EditTest({ record }) {
             {({ scopedFormData, getSource }) => (
               <ArrayInput source={getSource("choices")} validate={[required()]} label="CHOICES">
                 <SimpleFormIterator
-                  disableAdd={scopedFormData && scopedFormData.choices.length > 1}
+                  disableAdd={
+                    scopedFormData && scopedFormData.choices && scopedFormData.choices.length > 1
+                  }
                 >
                   <TextInput source="answer" validate={[required()]} label="Answer" />
                   <NullableBooleanInput source="correct" validate={[required()]} label="Correct" />


### PR DESCRIPTION
Hey ho 👋 
In Create test and edit test forms we want to hide the add option button when two options were added`true/false` 
This PR covers that, thanks @ssmirnow  for help 🥇  