### PR TITLE
[ME-155] Fix console warnings in admin panel

### DIFF
--- a/admin/src/views/App/components/ShowLesson/index.jsx
+++ b/admin/src/views/App/components/ShowLesson/index.jsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import {
   Show,
   TextField,
-  TopToolbar,
   UrlField,
   TabbedShowLayout,
   Tab,
@@ -18,12 +17,12 @@ export default function ShowLesson(props) {
   const [showAddButton, setShowAddButton] = useState(true);
 
   return (
-    <Show actions={<TopToolbar />} {...props}>
+    <Show {...props}>
       <TabbedShowLayout>
         <Tab label="lesson">
           <TextField source="name" />
           <TextField source="description" />
-          <UrlField source="pdf_file" />
+          <UrlField emptyText="No pdf file" source="pdf_file" />
           <UrlField source="url" />
           <TextField source="subject" />
           <TextField source="grade" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -3067,7 +3067,7 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
-"@types/js-cookie@2.2.6", "@types/js-cookie@^2.2.6":
+"@types/js-cookie@2.2.6":
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-2.2.6.tgz#f1a1cb35aff47bc5cfb05cb0c441ca91e914c26f"
   integrity sha512-+oY0FDTO2GYKEV0YPvSshGq9t7YozVkgvXLty7zogQNuCxBhT9/3INX9Q7H1aRZ4SUDRXAKlJuA4EA5nTt7SNw==
@@ -8377,7 +8377,7 @@ jest@25.4.0:
     import-local "^3.0.2"
     jest-cli "^25.4.0"
 
-js-cookie@2.2.1, js-cookie@^2.2.1:
+js-cookie@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
   integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==


### PR DESCRIPTION
Heyo 🧇 
The following warnings were haunting us since I can remember 😄 :
- "React does not recognize the `basePath` prop on a DOM element”
- “React does not recognize the `hasList` prop on a DOM element”
- “React does not recognize the `hasEdit` prop on a DOM element”
- "Warning: Failed prop type: The prop `children` is marked as required in `ForwardRef(Link)`, but its value is `null`."

Top three are fixed by removing redundant TopToolbar 🎱 ,
The last one is fixed by providing `emptyText` prop to UrlField to prevent null when no pdf is found.

Kudos @ssmirnow  for help