### PR TITLE
Add robots.txt

### DIFF
--- a/admin/public/robots.txt
+++ b/admin/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/app/public/robots.txt
+++ b/app/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Disallow: /subjects/


### PR DESCRIPTION
Add robots.txt and block some routes from indexing:
- admin panel - block all routes
- student's page - block all `/subjects/*` routes as they are accessible only for logged-in users